### PR TITLE
fix config path on print

### DIFF
--- a/lib/mix/tasks/phoenix_oauth2_provider.install.ex
+++ b/lib/mix/tasks/phoenix_oauth2_provider.install.ex
@@ -120,7 +120,7 @@ config :phoenix_oauth2_provider, PhoenixOauth2Provider,
         {:error, "Configuration was not added because one already exists!"}
       true ->
         File.write!(config_file, source <> "\n" <> string)
-        {:ok, "Your config/config.exs file was updated, and deps has been recompiled."}
+        {:ok, "Your #{config_file} file was updated, and deps has been recompiled."}
     end
   end
 


### PR DESCRIPTION
Looks like the `config/config.exs` is hard-coded which made me think for a moment that I didn't pass arg properly. This should print the right config file I believe.