### PR TITLE
Remove redundant code endpoint

### DIFF
--- a/lib/phoenix_oauth2_provider/controllers/authorization_controller.ex
+++ b/lib/phoenix_oauth2_provider/controllers/authorization_controller.ex
@@ -40,11 +40,6 @@ defmodule PhoenixOauth2Provider.AuthorizationController do
     |> redirect_or_render(conn)
   end
 
-  @spec show(Conn.t(), map(), map(), keyword()) :: Conn.t()
-  def show(conn, %{"code" => code}, _resource_owner, _config) do
-    render(conn, "show.html", code: code)
-  end
-
   defp redirect_or_render({:redirect, redirect_uri}, conn) do
     redirect(conn, external: redirect_uri)
   end

--- a/lib/phoenix_oauth2_provider/router.ex
+++ b/lib/phoenix_oauth2_provider/router.ex
@@ -68,7 +68,6 @@ defmodule PhoenixOauth2Provider.Router do
         scope "/authorize" do
           get "/", AuthorizationController, :new
           post "/", AuthorizationController, :create
-          get "/:code", AuthorizationController, :show
           delete "/", AuthorizationController, :delete
         end
         resources "/applications", ApplicationController, param: "uid"

--- a/lib/phoenix_oauth2_provider/views/authorization_view.ex
+++ b/lib/phoenix_oauth2_provider/views/authorization_view.ex
@@ -42,11 +42,4 @@ defmodule PhoenixOauth2Provider.AuthorizationView do
     <%% end %>
   </div>
   """
-
-  template "show.html",
-  """
-  <h1>Authorization code</h1>
-
-  <code><%%= @code %></code>
-  """
 end


### PR DESCRIPTION
The `/oauth/authorize/:code` or `PhoenixOauth2Provider.AuthorizationController.show` seems to have no real use since it just echoes the path param back to the user.