### PR TITLE
Split oath applications routes for more granular control

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ defmodule MyAppWeb.Router do
 end
 ```
 
+> Instead of `oauth_routes()` you can use both `oauth_authorize_routes()` and `oauth_applications_routes()` for more granular control.
+
 That's it! The following OAuth 2.0 routes will now be available in your app:
 
 ```text

--- a/lib/phoenix_oauth2_provider/router.ex
+++ b/lib/phoenix_oauth2_provider/router.ex
@@ -61,8 +61,36 @@ defmodule PhoenixOauth2Provider.Router do
 
         oauth_routes()
       end
+
+      # equivalent to
+      scope "/" do
+        pipe_through [:browser, :protected]
+
+        oauth_authorize_routes()
+        oauth_applications_routes()
+      end
   """
   defmacro oauth_routes(options \\ []) do
+    quote location: :keep do
+      oauth_authorize_routes(unquote(options))
+      oauth_applications_routes(unquote(options))
+    end
+  end
+
+  @doc """
+  OAuth 2.0 browser routes macro.
+
+  Use this macro to define the authorization related protected browser oauth routes (authorize application by user and revoke previous approvals).
+
+  ## Example
+
+      scope "/" do
+        pipe_through [:browser, :protected]
+
+        oauth_authorize_routes()
+      end
+  """
+  defmacro oauth_authorize_routes(options \\ []) do
     quote location: :keep do
       oauth_scope unquote(options), @phoenix_oauth2_provider_config do
         scope "/authorize" do
@@ -71,8 +99,28 @@ defmodule PhoenixOauth2Provider.Router do
           get "/:code", AuthorizationController, :show
           delete "/", AuthorizationController, :delete
         end
-        resources "/applications", ApplicationController, param: "uid"
         resources "/authorized_applications", AuthorizedApplicationController, only: [:index, :delete], param: "uid"
+      end
+    end
+  end
+
+  @doc """
+  OAuth 2.0 browser routes macro.
+
+  Use this macro to define the applications related protected browser oauth routes (list, create, edit oauth applications).
+
+  ## Example
+
+      scope "/" do
+        pipe_through [:browser, :admin_protected]
+
+        oauth_applications_routes()
+      end
+  """
+  defmacro oauth_applications_routes(options \\ []) do
+    quote location: :keep do
+      oauth_scope unquote(options), @phoenix_oauth2_provider_config do
+        resources "/applications", ApplicationController, param: "uid"
       end
     end
   end


### PR DESCRIPTION
Split `oath_routes` into 2 separate macros to allow more granular control and for better protection of the `/oauth/application` endpoint, allowing for example only admins to view and manage their OAuth applications.

The changes are backwards compatible.

Closes #38 